### PR TITLE
Entity: Use @ElementCollection instead of @Basic

### DIFF
--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/entity/Game.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/entity/Game.java
@@ -5,6 +5,7 @@ import ch.uzh.ifi.seal.soprafs20.constant.GameStatus;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Internal Game Representation
@@ -23,8 +24,9 @@ public class Game implements Serializable {
     @GeneratedValue
     private Long id;
 
-    @Basic
-    private ArrayList<Long> playerIds;
+    @Column()
+    @ElementCollection
+    private List<Long> playerIds = new ArrayList<Long>();
 
     @Column(nullable = false)
     private int round;
@@ -32,8 +34,9 @@ public class Game implements Serializable {
     @Column(nullable = false)
     private GameStatus gameStatus;
 
-    @Basic
-    private ArrayList<String> words;
+    @Column()
+    @ElementCollection
+    private List<String> words = new ArrayList<String>();
 
     @Column(nullable = false)
     private int wordIndex;
@@ -44,8 +47,9 @@ public class Game implements Serializable {
     @Column(nullable = false)
     private Long activePlayerId;
 
-    @Basic
-    private ArrayList<String> clues;
+    @Column()
+    @ElementCollection
+    private List<String> clues = new ArrayList<String>();
 
     @Column(nullable = false)
     private int timestamp;
@@ -58,11 +62,11 @@ public class Game implements Serializable {
         this.id = id;
     }
 
-    public ArrayList<Long> getPlayerIds() {
+    public List<Long> getPlayerIds() {
         return playerIds;
     }
 
-    public void setPlayerIds(ArrayList<Long> playerIds) {
+    public void setPlayerIds(List<Long> playerIds) {
         this.playerIds = playerIds;
     }
 
@@ -82,11 +86,11 @@ public class Game implements Serializable {
         this.gameStatus = gameStatus;
     }
 
-    public ArrayList<String> getWords() {
+    public List<String> getWords() {
         return words;
     }
 
-    public void setWords(ArrayList<String> words) {
+    public void setWords(List<String> words) {
         this.words = words;
     }
 
@@ -114,11 +118,11 @@ public class Game implements Serializable {
         this.activePlayerId = activePlayerId;
     }
 
-    public ArrayList<String> getClues() {
+    public List<String> getClues() {
         return clues;
     }
 
-    public void setClues(ArrayList<String> clues) {
+    public void setClues(List<String> clues) {
         this.clues = clues;
     }
 

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/entity/Lobby.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/entity/Lobby.java
@@ -3,6 +3,7 @@ package ch.uzh.ifi.seal.soprafs20.entity;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Internal Lobby Representation
@@ -27,8 +28,9 @@ public class Lobby implements Serializable {
     @Column(nullable = false)
     private Long hostPlayerId;
 
-    @Basic
-    private ArrayList<Long> playerIds;
+    @Column()
+    @ElementCollection
+    private List<Long> playerIds = new ArrayList<Long>();
 
     @Column(nullable = false)
     private Long chatId;
@@ -60,11 +62,11 @@ public class Lobby implements Serializable {
         this.hostPlayerId = hostPlayerId;
     }
 
-    public ArrayList<Long> getPlayerIds() {
+    public List<Long> getPlayerIds() {
         return playerIds;
     }
 
-    public void setPlayerIds(ArrayList<Long> playerIds) {
+    public void setPlayerIds(List<Long> playerIds) {
         this.playerIds = playerIds;
     }
 

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/entity/User.java
@@ -5,6 +5,7 @@ import ch.uzh.ifi.seal.soprafs20.constant.UserStatus;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Date;
 
 
@@ -40,8 +41,9 @@ public class User implements Serializable {
     @Column(nullable = false)
     private UserStatus status;
 
-    @Basic
-    private ArrayList<Long> invitations;
+    @Column()
+    @ElementCollection
+    private List<Long> invitations = new ArrayList<Long>();
 
     @Column
     private int rank;
@@ -168,11 +170,11 @@ public class User implements Serializable {
         this.username = userName;
     }
 
-    public ArrayList<Long> getInvitations() {
+    public List<Long> getInvitations() {
         return invitations;
     }
 
-    public void setInvitations(ArrayList<Long> invitations) {
+    public void setInvitations(List<Long> invitations) {
         this.invitations = invitations;
     }
 

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/ChatMessageDTO.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/ChatMessageDTO.java
@@ -1,8 +1,6 @@
 package ch.uzh.ifi.seal.soprafs20.rest.dto;
 
 import ch.uzh.ifi.seal.soprafs20.constant.GameStatus;
-import java.util.ArrayList;
-
 
 public class ChatMessageDTO {
 

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/GameGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/GameGetDTO.java
@@ -2,18 +2,18 @@ package ch.uzh.ifi.seal.soprafs20.rest.dto;
 
 import ch.uzh.ifi.seal.soprafs20.constant.GameStatus;
 
-import java.util.ArrayList;
+import java.util.List;
 
 
 public class GameGetDTO {
 
     private Long id;
-    private ArrayList<Long> playerIds;
+    private List<Long> playerIds;
     private int round;
     private GameStatus gameStatus;
     private int score;
     private Long activePlayerId;
-    private ArrayList<String> clues;
+    private List<String> clues;
     private int timestamp;
 
     public Long getId() {
@@ -24,11 +24,11 @@ public class GameGetDTO {
         this.id = id;
     }
 
-    public ArrayList<Long> getPlayerIds() {
+    public List<Long> getPlayerIds() {
         return playerIds;
     }
 
-    public void setPlayerIds(ArrayList<Long> playerIds) {
+    public void setPlayerIds(List<Long> playerIds) {
         this.playerIds = playerIds;
     }
 
@@ -64,11 +64,11 @@ public class GameGetDTO {
         this.activePlayerId = activePlayerId;
     }
 
-    public ArrayList<String> getClues() {
+    public List<String> getClues() {
         return clues;
     }
 
-    public void setClues(ArrayList<String> clues) {
+    public void setClues(List<String> clues) {
         this.clues = clues;
     }
 

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/GamePostDTO.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/GamePostDTO.java
@@ -1,16 +1,16 @@
 package ch.uzh.ifi.seal.soprafs20.rest.dto;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class GamePostDTO {
 
-    private ArrayList<Long> playerIds;
+    private List<Long> playerIds;
 
-    public ArrayList<Long> getPlayerIds() {
+    public List<Long> getPlayerIds() {
         return playerIds;
     }
 
-    public void setPlayerIds(ArrayList<Long> playerIds) {
+    public void setPlayerIds(List<Long> playerIds) {
         this.playerIds = playerIds;
     }
 }

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/GamePutDTO.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/GamePutDTO.java
@@ -1,7 +1,5 @@
 package ch.uzh.ifi.seal.soprafs20.rest.dto;
 
-import java.util.ArrayList;
-
 public class GamePutDTO {
 
     private int wordIndex;

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/LobbyGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/LobbyGetDTO.java
@@ -1,13 +1,13 @@
 package ch.uzh.ifi.seal.soprafs20.rest.dto;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class LobbyGetDTO {
 
     private Long id;
     private String name;
     private Long hostPlayerId;
-    private ArrayList<Long> playerIds;
+    private List<Long> playerIds;
     private Long gameId;
 
     public Long getId() {
@@ -34,11 +34,11 @@ public class LobbyGetDTO {
         this.hostPlayerId = hostPlayerId;
     }
 
-    public ArrayList<Long> getPlayerIds() {
+    public List<Long> getPlayerIds() {
         return playerIds;
     }
 
-    public void setPlayerIds(ArrayList<Long> playerIds) {
+    public void setPlayerIds(List<Long> playerIds) {
         this.playerIds = playerIds;
     }
 

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/LobbyPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/LobbyPostDTO.java
@@ -1,12 +1,12 @@
 package ch.uzh.ifi.seal.soprafs20.rest.dto;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class LobbyPostDTO {
 
     private String name;
     private Long hostPlayerId;
-    private ArrayList<Long> playerIds;
+    private List<Long> playerIds;
 
     public String getName() {
         return name;
@@ -24,11 +24,11 @@ public class LobbyPostDTO {
         this.hostPlayerId = hostPlayerId;
     }
 
-    public ArrayList<Long> getPlayerIds() {
+    public List<Long> getPlayerIds() {
         return playerIds;
     }
 
-    public void setPlayerIds(ArrayList<Long> playerIds) {
+    public void setPlayerIds(List<Long> playerIds) {
         this.playerIds = playerIds;
     }
 }

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/UserGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/rest/dto/UserGetDTO.java
@@ -2,7 +2,7 @@ package ch.uzh.ifi.seal.soprafs20.rest.dto;
 
 import ch.uzh.ifi.seal.soprafs20.constant.UserStatus;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Date;
 
 public class UserGetDTO {
@@ -21,7 +21,7 @@ public class UserGetDTO {
     private Date creationDate;
     private long gameId;
     private long lobbyId;
-    private ArrayList<Long> invitations;
+    private List<Long> invitations;
 
 
     public String getPassword() {
@@ -101,11 +101,11 @@ public class UserGetDTO {
         this.birthDay = birthDay;
     }
 
-    public ArrayList<Long> getInvitations() {
+    public List<Long> getInvitations() {
         return invitations;
     }
 
-    public void setInvitations(ArrayList<Long> invitations) {
+    public void setInvitations(List<Long> invitations) {
         this.invitations = invitations;
     }
 


### PR DESCRIPTION
The Basic value collection, was not read correctly by whatever JPA casted the value to. This commit fixes this by changing from the @Basic annotation to an @ElementCollection. @ElementCollection only takes the abstract List type as a single value, so we need to redefine all values from ArrayList to List. The initialization in the entity ensures that we still get the functionality of the ArrayList.