### PR TITLE
Implement Long Polling Asynchronous Requests

### DIFF
--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/controller/GameController.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/controller/GameController.java
@@ -1,16 +1,14 @@
 package ch.uzh.ifi.seal.soprafs20.controller;
 
 import ch.uzh.ifi.seal.soprafs20.entity.Game;
-import ch.uzh.ifi.seal.soprafs20.rest.dto.GameGetDTO;
-import ch.uzh.ifi.seal.soprafs20.rest.dto.GamePostDTO;
-import ch.uzh.ifi.seal.soprafs20.rest.dto.GamePutDTO;
-import ch.uzh.ifi.seal.soprafs20.rest.dto.GameStat;
+import ch.uzh.ifi.seal.soprafs20.rest.dto.*;
 import ch.uzh.ifi.seal.soprafs20.rest.mapper.DTOMapper;
 import ch.uzh.ifi.seal.soprafs20.service.GameService;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.async.DeferredResult;
 
 import java.net.URI;
 
@@ -47,6 +45,27 @@ public class GameController {
     public GameGetDTO getGameInfo(@RequestHeader("X-Auth-Token") String token, @PathVariable("id") long id) {
         Game game = gameService.getExistingGame(id);
         return DTOMapper.INSTANCE.convertEntityToGameGetDTO(game);
+    }
+
+    @GetMapping("/gamepoll/{gameId}/subscribe")
+    @ResponseStatus(HttpStatus.OK)
+    public void subscribe(@PathVariable Long gameId){
+        gameService.subscribe(gameId);
+    }
+
+    @GetMapping("/gamepoll/{gameId}/unsubscribe")
+    @ResponseStatus(HttpStatus.OK)
+    public void unsubscribe(@PathVariable Long gameId){
+        gameService.unsubscribe(gameId);
+    }
+
+    @GetMapping("/gamepoll/{gameId}")
+    @ResponseStatus(HttpStatus.OK)
+    DeferredResult<GameGetDTO> poll(@PathVariable Long gameId){
+        // create deferred result that times out after 60 seconds
+        final DeferredResult<GameGetDTO> finalResult  = new DeferredResult<GameGetDTO>(60000l);
+        gameService.pollGetUpdate(finalResult, gameId);
+        return finalResult;
     }
 
     @PutMapping("/game/{id}/number")

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/controller/LobbyController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.async.DeferredResult;
 
 import java.util.ArrayList;
 import java.net.URI;
@@ -57,6 +58,27 @@ public class LobbyController {
     public LobbyGetDTO getLobbyInfo(@RequestHeader("X-Auth-Token") String token, @PathVariable("id") long id) {
         Lobby lobby = lobbyService.getLobby(id);
         return DTOMapper.INSTANCE.convertEntityToLobbyGetDTO(lobby);
+    }
+
+    @GetMapping("/lobbypoll/{lobbyId}/subscribe")
+    @ResponseStatus(HttpStatus.OK)
+    public void subscribe(@PathVariable Long lobbyId){
+        lobbyService.subscribe(lobbyId);
+    }
+
+    @GetMapping("/lobbypoll/{lobbyId}/unsubscribe")
+    @ResponseStatus(HttpStatus.OK)
+    public void unsubscribe(@PathVariable Long lobbyId){
+        lobbyService.unsubscribe(lobbyId);
+    }
+
+    @GetMapping("/lobbypoll/{lobbyId}")
+    @ResponseStatus(HttpStatus.OK)
+    DeferredResult<LobbyGetDTO> poll(@PathVariable Long lobbyId){
+        // create deferred result that times out after 60 seconds
+        final DeferredResult<LobbyGetDTO> finalResult  = new DeferredResult<LobbyGetDTO>(60000l);
+        lobbyService.pollGetUpdate(finalResult, lobbyId);
+        return finalResult;
     }
 
     @PutMapping("/lobby/{id}")

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/entity/Game.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/entity/Game.java
@@ -85,6 +85,29 @@ public class Game implements Serializable {
     @ElementCollection
     private List<Long> countAccept = new ArrayList<>();
 
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + this.getId() +
+                ", playerIds='" + this.getPlayerIds() +
+                ", round='" + this.getRound() +
+                ", gameStatus='" + this.getGameStatus() +
+                ", words=" + this.getWords() +
+                ", wordIndex='" + this.getWordIndex() +
+                ", lastWordIndex=" + this.getLastWordIndex() +
+                ", roundScore=" + this.getRoundScore() +
+                ", activePlayerId=" + this.getActivePlayerId()+
+                ", clues=" + this.getClues() +
+                ", score=" + this.getScore() +
+                ", timestamp='" + this.getTimestamp() +
+                ", wordsGuessedWrong=" + this.getWordsGuessedWrong() +
+                ", cardStackCount=" + this.getCardStackCount() +
+                ", cardGuessedCount=" + this.getCardGuessedCount() +
+                ", cardStatus=" + this.getCardStatus() +
+                ", countAccept=" + this.getCountAccept() +
+                '}';
+    }
+
     public List<Long> getCountAccept() {return countAccept;}
 
     public void setCountAccept(List<Long> accept) {this.countAccept = accept;}

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/entity/Lobby.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/entity/Lobby.java
@@ -29,7 +29,7 @@ public class Lobby implements Serializable {
     private Long hostPlayerId;
 
     @Column()
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     private List<Long> playerIds = new ArrayList<>();
 
     @Column

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/entity/User.java
@@ -41,8 +41,7 @@ public class User implements Serializable {
     private UserStatus status;
 
     @Column()
-    @ElementCollection
-
+    @ElementCollection(fetch = FetchType.EAGER)
     private List<Long> invitations = new ArrayList<>();
 
     @Column
@@ -66,6 +65,12 @@ public class User implements Serializable {
     @Column
     private long gameId;
 
+    @Column
+    private long lobbyId;
+
+    @Column
+    private String image;
+
     @Override
     public String toString() {
         return "User{" +
@@ -86,13 +91,6 @@ public class User implements Serializable {
                 ", lobbyId=" + lobbyId +
                 '}';
     }
-
-    @Column
-    private long lobbyId;
-
-    @Column
-    private String image;
-
 
     public static long getSerialVersionUID() {
         return serialVersionUID;

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/service/GamePollService.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/service/GamePollService.java
@@ -1,0 +1,97 @@
+package ch.uzh.ifi.seal.soprafs20.service;
+
+import ch.uzh.ifi.seal.soprafs20.entity.Game;
+import ch.uzh.ifi.seal.soprafs20.repository.GameRepository;
+import ch.uzh.ifi.seal.soprafs20.exceptions.ServiceException;
+import ch.uzh.ifi.seal.soprafs20.rest.dto.*;
+import ch.uzh.ifi.seal.soprafs20.rest.mapper.DTOMapper;
+import ch.uzh.ifi.seal.soprafs20.worker.GamePollWorker;
+import ch.uzh.ifi.seal.soprafs20.utils.Pair;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+@Service
+@Transactional
+public class GamePollService implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(GamePollService.class);
+
+    private ArrayList<Pair<Long, DeferredResult<GameGetDTO>>> resultList = new ArrayList<Pair<Long, DeferredResult<GameGetDTO>>>();
+    private GamePollWorker worker;
+
+    private Thread thread;
+
+    private volatile boolean start = true;
+
+    @Autowired
+    public GamePollService(GameRepository gameRepository) {
+        worker = new GamePollWorker(gameRepository);
+    }
+
+    public void subscribe(Long id) {
+        logger.info("Starting server");
+        worker.subscribe(id);
+        startThread();
+    }
+
+    public void unsubscribe(Long id) {
+        worker.unsubscribe(id);
+    }
+
+    private void startThread() {
+        if (start) {
+            synchronized (this) {
+                if (start) {
+                    start = false;
+                    thread = new Thread(this, "Service Thread");
+                    thread.start();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+
+      while (true) {
+        try {
+            Pair<Long, Game> message = worker.queue.take();
+            ArrayList<Pair<Long, DeferredResult<GameGetDTO>>> resolvedRequests = new ArrayList<>();
+            for (Pair<Long, DeferredResult<GameGetDTO>> request: resultList) {
+                //compare ids
+                resolvedRequests.add(request);
+                if (request.x == message.x) {
+                    // set the result
+                    request.y.setResult(DTOMapper.INSTANCE.convertEntityToGameGetDTO(message.y));
+                }
+            }
+            for (Pair<Long, DeferredResult<GameGetDTO>> resolved: resolvedRequests) {
+                resultList.remove(resolved);
+            }
+        } catch (InterruptedException e) {
+            throw new ServiceException("Cannot get latest update. ");
+        }
+      }
+    }
+
+    public void pollGetUpdate(DeferredResult<GameGetDTO> result, Long id) {
+        resultList.add(new Pair<Long, DeferredResult<GameGetDTO>> (id, result));
+    }
+}

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/service/GameService.java
@@ -8,8 +8,7 @@ import ch.uzh.ifi.seal.soprafs20.exceptions.NotFoundException;
 import ch.uzh.ifi.seal.soprafs20.exceptions.ServiceException;
 import ch.uzh.ifi.seal.soprafs20.repository.GameRepository;
 import ch.uzh.ifi.seal.soprafs20.repository.UserRepository;
-import ch.uzh.ifi.seal.soprafs20.rest.dto.GamePutDTO;
-import ch.uzh.ifi.seal.soprafs20.rest.dto.GameStat;
+import ch.uzh.ifi.seal.soprafs20.rest.dto.*;
 import ch.uzh.ifi.seal.soprafs20.wordcheck.Stemmer;
 import ch.uzh.ifi.seal.soprafs20.wordcheck.WordCheck;
 import org.slf4j.Logger;
@@ -18,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.async.DeferredResult;
 
 import java.time.Duration;
 import java.time.LocalTime;
@@ -40,6 +40,7 @@ public class GameService {
 
     private GameRepository gameRepository;
     private UserRepository userRepository;
+    private GamePollService gamePollService;
     private Random rand = new Random();
     private WordCheck wordChecker = new WordCheck();
     Stemmer stemCheck = new Stemmer();
@@ -49,6 +50,32 @@ public class GameService {
     public GameService(@Qualifier("gameRepository") GameRepository gameRepository, @Qualifier("userRepository") UserRepository userRepository) {
         this.gameRepository = gameRepository;
         this.userRepository = userRepository;
+        this.gamePollService = new GamePollService(gameRepository);
+    }
+
+    // subscription method for a certain game id
+    public void subscribe(Long id) {
+        try {
+            gameRepository.findById(id).get();
+        } catch (Exception e) {
+            throw new NotFoundException("Cannot subscribe to a non-existing game");
+        }
+        gamePollService.subscribe(id);
+    }
+
+    // unsubscription method for a certain game id
+    public void unsubscribe(Long id) {
+        gamePollService.unsubscribe(id);
+    }
+
+    // async, returns once there is a change for the game id
+    public void pollGetUpdate(DeferredResult<GameGetDTO> result, Long id) {
+        try {
+            gameRepository.findById(id).get();
+        } catch (Exception e) {
+            throw new NotFoundException("Cannot poll for a non-existing game");
+        }
+        gamePollService.pollGetUpdate(result, id);
     }
 
     public Long createGame(List<Long> players) {

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/service/LobbyPollService.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/service/LobbyPollService.java
@@ -1,0 +1,98 @@
+package ch.uzh.ifi.seal.soprafs20.service;
+
+import ch.uzh.ifi.seal.soprafs20.entity.Lobby;
+import ch.uzh.ifi.seal.soprafs20.repository.LobbyRepository;
+import ch.uzh.ifi.seal.soprafs20.exceptions.ServiceException;
+import ch.uzh.ifi.seal.soprafs20.rest.dto.*;
+import ch.uzh.ifi.seal.soprafs20.rest.mapper.DTOMapper;
+import ch.uzh.ifi.seal.soprafs20.worker.LobbyPollWorker;
+import ch.uzh.ifi.seal.soprafs20.utils.Pair;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+//@Service("LobbyPollService")
+@Service
+@Transactional
+public class LobbyPollService implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(LobbyPollService.class);
+
+    private ArrayList<Pair<Long, DeferredResult<LobbyGetDTO>>> resultList = new ArrayList<Pair<Long, DeferredResult<LobbyGetDTO>>>();
+    private LobbyPollWorker worker;
+
+    private Thread thread;
+
+    private volatile boolean start = true;
+
+    @Autowired
+    public LobbyPollService(LobbyRepository lobbyRepository) {
+        worker = new LobbyPollWorker(lobbyRepository);
+    }
+
+    public void subscribe(Long id) {
+        logger.info("Starting server");
+        worker.subscribe(id);
+        startThread();
+    }
+
+    public void unsubscribe(Long id) {
+        worker.unsubscribe(id);
+    }
+
+    private void startThread() {
+        if (start) {
+            synchronized (this) {
+                if (start) {
+                    start = false;
+                    thread = new Thread(this, "Service Thread");
+                    thread.start();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+
+      while (true) {
+        try {
+            Pair<Long, Lobby> message = worker.queue.take();
+            ArrayList<Pair<Long, DeferredResult<LobbyGetDTO>>> resolvedRequests = new ArrayList<>();
+            for (Pair<Long, DeferredResult<LobbyGetDTO>> request: resultList) {
+                //compare ids
+                resolvedRequests.add(request);
+                if (request.x == message.x) {
+                    // set the result
+                    request.y.setResult(DTOMapper.INSTANCE.convertEntityToLobbyGetDTO(message.y));
+                }
+            }
+            for (Pair<Long, DeferredResult<LobbyGetDTO>> resolved: resolvedRequests) {
+                resultList.remove(resolved);
+            }
+        } catch (InterruptedException e) {
+            throw new ServiceException("Cannot get latest update. ");
+        }
+      }
+    }
+
+    public void pollGetUpdate(DeferredResult<LobbyGetDTO> result, Long id) {
+        resultList.add(new Pair<Long, DeferredResult<LobbyGetDTO>> (id, result));
+    }
+}

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/service/UserPollService.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/service/UserPollService.java
@@ -1,0 +1,99 @@
+package ch.uzh.ifi.seal.soprafs20.service;
+
+import ch.uzh.ifi.seal.soprafs20.constant.UserStatus;
+import ch.uzh.ifi.seal.soprafs20.entity.User;
+import ch.uzh.ifi.seal.soprafs20.repository.UserRepository;
+import ch.uzh.ifi.seal.soprafs20.exceptions.ServiceException;
+import ch.uzh.ifi.seal.soprafs20.rest.dto.*;
+import ch.uzh.ifi.seal.soprafs20.rest.mapper.DTOMapper;
+import ch.uzh.ifi.seal.soprafs20.worker.UserPollWorker;
+import ch.uzh.ifi.seal.soprafs20.utils.Pair;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+//@Service("UserPollService")
+@Service
+@Transactional
+public class UserPollService implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserPollService.class);
+
+    private ArrayList<Pair<Long, DeferredResult<UserGetDTO>>> resultList = new ArrayList<Pair<Long, DeferredResult<UserGetDTO>>>();
+    private UserPollWorker worker;
+
+    private Thread thread;
+
+    private volatile boolean start = true;
+
+    @Autowired
+    public UserPollService(UserRepository userRepository) {
+        worker = new UserPollWorker(userRepository);
+    }
+
+    public void subscribe(Long id) {
+        logger.info("Starting server");
+        worker.subscribe(id);
+        startThread();
+    }
+
+    public void unsubscribe(Long id) {
+        worker.unsubscribe(id);
+    }
+
+    private void startThread() {
+        if (start) {
+            synchronized (this) {
+                if (start) {
+                    start = false;
+                    thread = new Thread(this, "Service Thread");
+                    thread.start();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+
+      while (true) {
+        try {
+            Pair<Long, User> message = worker.queue.take();
+            ArrayList<Pair<Long, DeferredResult<UserGetDTO>>> resolvedRequests = new ArrayList<>();
+            for (Pair<Long, DeferredResult<UserGetDTO>> request: resultList) {
+                //compare ids
+                resolvedRequests.add(request);
+                if (request.x == message.x) {
+                    // set the result
+                    request.y.setResult(DTOMapper.INSTANCE.convertEntityToUserGetDTO(message.y));
+                }
+            }
+            for (Pair<Long, DeferredResult<UserGetDTO>> resolved: resolvedRequests) {
+                resultList.remove(resolved);
+            }
+        } catch (InterruptedException e) {
+            throw new ServiceException("Cannot get latest update. ");
+        }
+      }
+    }
+
+    public void pollGetUpdate(DeferredResult<UserGetDTO> result, Long id) {
+        resultList.add(new Pair<Long, DeferredResult<UserGetDTO>> (id, result));
+    }
+}

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/utils/Pair.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/utils/Pair.java
@@ -1,0 +1,14 @@
+package ch.uzh.ifi.seal.soprafs20.utils;
+
+public class Pair<X, Y> {
+  public final X x;
+  public Y y;
+  public Pair(X x, Y y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  public Y getY() {
+      return this.y;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/worker/GamePollWorker.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/worker/GamePollWorker.java
@@ -1,0 +1,114 @@
+package ch.uzh.ifi.seal.soprafs20.worker;
+
+import ch.uzh.ifi.seal.soprafs20.entity.Game;
+import ch.uzh.ifi.seal.soprafs20.repository.GameRepository;
+import ch.uzh.ifi.seal.soprafs20.exceptions.ServiceException;
+import ch.uzh.ifi.seal.soprafs20.exceptions.NotFoundException;
+import ch.uzh.ifi.seal.soprafs20.utils.Pair;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+@Service
+@Transactional
+public class GamePollWorker implements Runnable {
+
+    private Thread thread;
+
+    private volatile boolean start = true;
+
+    public LinkedBlockingQueue<Pair<Long, Game>> queue = new LinkedBlockingQueue<>();
+
+    private ArrayList<Pair<Long, Game>> subscriptions = new ArrayList();
+    private GameRepository gameRepository;
+
+    @Autowired
+    public GamePollWorker(GameRepository gameRepository) {
+        this.gameRepository = gameRepository;
+    }
+
+    // subscribe the resource
+    public void subscribe(Long id) {
+        // create a new subscription
+        Pair<Long, Game> subscribed = new Pair(id, getExistingGame(id));
+        // check if we are already subscribed to that game
+        for (Pair<Long, Game> subscription: subscriptions) {
+            if (subscription.x == id) {
+                return;
+            }
+        }
+        // add the subcription to the queue
+        subscriptions.add(subscribed);
+        startThread();
+    }
+
+    // make sure that at least one thread is running
+    private void startThread() {
+        if (start) {
+            synchronized (this) {
+                if (start) {
+                    start = false;
+                    thread = new Thread(this, "Game Worker Thread");
+                    thread.start();
+                }
+            }
+        }
+    }
+
+    // unsubscribe the resource
+    public void unsubscribe(Long id) {
+        Iterator<Pair<Long, Game>> iter = subscriptions.iterator();
+        while (iter.hasNext()) {
+            if (iter.next().x == id) {
+                iter.remove();
+            }
+        }
+    }
+
+    private Game getExistingGame(long id) {
+        Optional<Game> optionalGame = gameRepository.findById(id);
+        if (!optionalGame.isPresent()) {
+            throw new NotFoundException(String.format("Could not find game with id %d.", id));
+        }
+        return optionalGame.get();
+    }
+
+    @Override
+    public void run() {
+        while(true) {
+            try {
+                for (Pair<Long, Game> subscription: subscriptions) {
+                    Game game = getExistingGame(subscription.x);
+                    Game subscribedGame = subscription.y;
+
+                    if (!game.toString().equals(subscribedGame.toString())) {
+                        Pair<Long, Game> newData = new Pair(subscription.x, game);
+                        queue.add(newData);
+                        subscription.y = game;
+                    }
+                }
+                TimeUnit.SECONDS.sleep(2);
+             } catch (InterruptedException e) {
+                 throw new ServiceException("Cannot get latest update. ");
+             }
+        }
+    }
+}

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/worker/LobbyPollWorker.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/worker/LobbyPollWorker.java
@@ -1,0 +1,114 @@
+package ch.uzh.ifi.seal.soprafs20.worker;
+
+import ch.uzh.ifi.seal.soprafs20.entity.Lobby;
+import ch.uzh.ifi.seal.soprafs20.repository.LobbyRepository;
+import ch.uzh.ifi.seal.soprafs20.exceptions.ServiceException;
+import ch.uzh.ifi.seal.soprafs20.exceptions.NotFoundException;
+import ch.uzh.ifi.seal.soprafs20.utils.Pair;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+@Service
+@Transactional
+public class LobbyPollWorker implements Runnable {
+
+    private Thread thread;
+
+    private volatile boolean start = true;
+
+    public LinkedBlockingQueue<Pair<Long, Lobby>> queue = new LinkedBlockingQueue<>();
+
+    private ArrayList<Pair<Long, Lobby>> subscriptions = new ArrayList();
+    private LobbyRepository lobbyRepository;
+
+    @Autowired
+    public LobbyPollWorker(LobbyRepository lobbyRepository) {
+        this.lobbyRepository = lobbyRepository;
+    }
+
+    // subscribe the resource
+    public void subscribe(Long id) {
+        // create a new subscription
+        Pair<Long, Lobby> subscribed = new Pair(id, getExistingLobby(id));
+        // check if we are already subscribed to that lobby
+        for (Pair<Long, Lobby> subscription: subscriptions) {
+            if (subscription.x == id) {
+                return;
+            }
+        }
+        // add the subcription to the queue
+        subscriptions.add(subscribed);
+        startThread();
+    }
+
+    // make sure that at least one thread is running
+    private void startThread() {
+        if (start) {
+            synchronized (this) {
+                if (start) {
+                    start = false;
+                    thread = new Thread(this, "Lobby Worker Thread");
+                    thread.start();
+                }
+            }
+        }
+    }
+
+    // unsubscribe the resource
+    public void unsubscribe(Long id) {
+        Iterator<Pair<Long, Lobby>> iter = subscriptions.iterator();
+        while (iter.hasNext()) {
+            if (iter.next().x == id) {
+                iter.remove();
+            }
+        }
+    }
+
+    private Lobby getExistingLobby(long id) {
+        Optional<Lobby> optionalLobby = lobbyRepository.findById(id);
+        if (!optionalLobby.isPresent()) {
+            throw new NotFoundException(String.format("Could not find lobby with id %d.", id));
+        }
+        return optionalLobby.get();
+    }
+
+    @Override
+    public void run() {
+        while(true) {
+            try {
+                for (Pair<Long, Lobby> subscription: subscriptions) {
+                    Lobby lobby = getExistingLobby(subscription.x);
+                    Lobby subscribedLobby = subscription.y;
+
+                    if (!lobby.toString().equals(subscribedLobby.toString())) {
+                        Pair<Long, Lobby> newData = new Pair(subscription.x, lobby);
+                        queue.add(newData);
+                        subscription.y = lobby;
+                    }
+                }
+                TimeUnit.SECONDS.sleep(2);
+             } catch (InterruptedException e) {
+                 throw new ServiceException("Cannot get latest update. ");
+             }
+        }
+    }
+}

--- a/src/main/java/ch/uzh/ifi/seal/soprafs20/worker/UserPollWorker.java
+++ b/src/main/java/ch/uzh/ifi/seal/soprafs20/worker/UserPollWorker.java
@@ -1,0 +1,115 @@
+package ch.uzh.ifi.seal.soprafs20.worker;
+
+import ch.uzh.ifi.seal.soprafs20.constant.UserStatus;
+import ch.uzh.ifi.seal.soprafs20.entity.User;
+import ch.uzh.ifi.seal.soprafs20.repository.UserRepository;
+import ch.uzh.ifi.seal.soprafs20.exceptions.ServiceException;
+import ch.uzh.ifi.seal.soprafs20.exceptions.NotFoundException;
+import ch.uzh.ifi.seal.soprafs20.utils.Pair;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+@Service
+@Transactional
+public class UserPollWorker implements Runnable {
+
+    private Thread thread;
+
+    private volatile boolean start = true;
+
+    public LinkedBlockingQueue<Pair<Long, User>> queue = new LinkedBlockingQueue<>();
+
+    private ArrayList<Pair<Long, User>> subscriptions = new ArrayList();
+    private UserRepository userRepository;
+
+    @Autowired
+    public UserPollWorker(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    // subscribe the resource
+    public void subscribe(Long id) {
+        // create a new subscription
+        Pair<Long, User> subscribed = new Pair(id, getExistingUser(id));
+        // check if we are already subscribed to that user
+        for (Pair<Long, User> subscription: subscriptions) {
+            if (subscription.x == id) {
+                return;
+            }
+        }
+        // add the subcription to the queue
+        subscriptions.add(subscribed);
+        startThread();
+    }
+
+    // make sure that at least one thread is running
+    private void startThread() {
+        if (start) {
+            synchronized (this) {
+                if (start) {
+                    start = false;
+                    thread = new Thread(this, "User Worker Thread");
+                    thread.start();
+                }
+            }
+        }
+    }
+
+    // unsubscribe the resource
+    public void unsubscribe(Long id) {
+        Iterator<Pair<Long, User>> iter = subscriptions.iterator();
+        while (iter.hasNext()) {
+            if (iter.next().x == id) {
+                iter.remove();
+            }
+        }
+    }
+
+    private User getExistingUser(long id) {
+        Optional<User> optionalUser = userRepository.findById(id);
+        if (!optionalUser.isPresent()) {
+            throw new NotFoundException(String.format("Could not find user with id %d.", id));
+        }
+        return optionalUser.get();
+    }
+
+    @Override
+    public void run() {
+        while(true) {
+            try {
+                for (Pair<Long, User> subscription: subscriptions) {
+                    User user = getExistingUser(subscription.x);
+                    User subscribedUser = subscription.y;
+
+                    if (!user.toString().equals(subscribedUser.toString())) {
+                        Pair<Long, User> newData = new Pair(subscription.x, user);
+                        queue.add(newData);
+                        subscription.y = user;
+                    }
+                }
+                TimeUnit.SECONDS.sleep(2);
+             } catch (InterruptedException e) {
+                 throw new ServiceException("Cannot get latest update. ");
+             }
+        }
+    }
+}

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,2 @@
 java.runtime.version=13
+spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true


### PR DESCRIPTION
Each of the main GET endpoints /user /game and /lobby now has its own /userpoll /lobbypoll and /gamepoll endpoint. These can be used to asynchronously get results from the game /user /game and /lobby entities. They return an object if their respective entity changes in the database.

The workflow to subscribe to asynchronous requests is simple. For asynchronously getting a user object with the user id 1:

1. Subscribe to the endpoint:

/userpoll/1/subscribe

2. Get the resource asynchronously:

/userpoll/1

An http request to this endpoint is only returned if something in the data changes. If nothing changes within 60 seconds, the http request returns with status code 503 unavailable instead.

3. Once done, unsubscribe from the resource:

/userpoll/1/unsubscribe

Each endpoint is implemented with its own state machine, which again consists of two separate state machines. One of them saves incoming requests into a list, the other puts changes into a queue. Again in the example of the user their functionality is implemented in UserPollService and UserPollWorker respectively.